### PR TITLE
Integrate Web3Forms submission for contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@ header.apx-header{display:flex;align-items:center;gap:18px;justify-content:space
 .apx-contact__form{display:none;margin-top:8px;padding:12px;background:#fff;border:1px solid #ddd;border-radius:12px;box-shadow:0 8px 20px rgba(0,0,0,.15);width:min(92vw,340px)}
 .apx-contact__form input,.apx-contact__form select,.apx-contact__form textarea{width:100%;margin:.4rem 0;padding:.65rem;border:1px solid #ccc;border-radius:8px}
 .apx-contact__form button{width:100%;padding:.75rem;background:var(--apx-orange);color:#fff;border:0;border-radius:8px;font-weight:700}
+.apx-contact__form button[disabled]{opacity:.7}
+.apx-contact__status{margin:.5rem 0 0;font-size:.9rem;color:#0b7;min-height:1.2em}
+.apx-contact__status.is-error{color:#d22}
 .hp{position:absolute;left:-9999px}
 .portfolio{padding:24px 16px}
 .portfolio h2{margin:0 0 8px}
@@ -73,7 +76,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
 
 <aside class="apx-contact">
   <button class="apx-contact__toggle" aria-controls="apx-contact-form" aria-expanded="false">Get Free Quote</button>
-  <form id="apx-contact-form" class="apx-contact__form" action="/submit" method="post" novalidate>
+  <form id="apx-contact-form" class="apx-contact__form" action="https://api.web3forms.com/submit" method="post">
     <input type="text" name="name" placeholder="Your Name" required>
     <input type="tel" name="phone" placeholder="Phone Number" required inputmode="tel" pattern="[0-9\s\-()+]+">
     <input type="email" name="email" placeholder="Email" required>
@@ -86,6 +89,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
     <textarea name="message" placeholder="Tell us about your project"></textarea>
     <input type="text" name="website" tabindex="-1" autocomplete="off" class="hp">
     <button type="submit">Get Free Quote</button>
+    <p class="apx-contact__status" role="status" aria-live="polite"></p>
   </form>
 </aside>
 
@@ -147,9 +151,61 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
 </footer>
 
 <script>
-const t=document.querySelector('.apx-contact__toggle');
-const f=document.querySelector('.apx-contact__form');
-if(t&&f){t.addEventListener('click',()=>{const open=f.style.display==='block';f.style.display=open?'none':'block';t.setAttribute('aria-expanded',String(!open));});}
+const WEB3FORMS_ACCESS_KEY='a4c3f5af-0f1b-4ca7-9dfd-90c5a7931022';
+const contactToggle=document.querySelector('.apx-contact__toggle');
+const contactForm=document.querySelector('#apx-contact-form');
+if(contactToggle&&contactForm){
+  const honeypot=contactForm.querySelector('.hp');
+  const statusEl=contactForm.querySelector('.apx-contact__status');
+  const submitButton=contactForm.querySelector('button[type="submit"]');
+  contactToggle.addEventListener('click',()=>{
+    const open=contactForm.style.display==='block';
+    contactForm.style.display=open?'none':'block';
+    contactToggle.setAttribute('aria-expanded',String(!open));
+    if(!open&&statusEl){
+      statusEl.textContent='';
+      statusEl.classList.remove('is-error');
+    }
+  });
+  contactForm.addEventListener('submit',async event=>{
+    event.preventDefault();
+    if(!contactForm.reportValidity()) return;
+    if(honeypot&&honeypot.value.trim()) return;
+    const formData=new FormData(contactForm);
+    formData.append('access_key',WEB3FORMS_ACCESS_KEY);
+    formData.append('from_name','APEX Heat Pumps Website');
+    formData.append('subject','New heat pump quote request');
+    if(statusEl){
+      statusEl.textContent='Sending...';
+      statusEl.classList.remove('is-error');
+    }
+    if(submitButton){
+      submitButton.disabled=true;
+      submitButton.textContent='Sending...';
+    }
+    try{
+      const response=await fetch(contactForm.action,{method:'POST',body:formData,headers:{Accept:'application/json'}});
+      if(!response.ok) throw new Error('Network response was not ok');
+      const data=await response.json();
+      if(data.success){
+        if(statusEl) statusEl.textContent='Thanks! We will reach out shortly.';
+        contactForm.reset();
+      }else{
+        throw new Error(data.message||'Submission failed');
+      }
+    }catch(error){
+      if(statusEl){
+        statusEl.textContent='Sorry, something went wrong. Please call 604-442-6711.';
+        statusEl.classList.add('is-error');
+      }
+    }finally{
+      if(submitButton){
+        submitButton.disabled=false;
+        submitButton.textContent='Get Free Quote';
+      }
+    }
+  });
+}
 </script>
 
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- point the floating quote form to the Web3Forms endpoint with the updated access key
- add client-side submission handling with status messaging and button disable states
- reset the form feedback when the drawer is reopened and keep the honeypot spam protection

## Testing
- not run (static site with no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68e156c02af0832d86d1baf32aabf12e