### PR TITLE
Add standalone calculator and placeholder pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About APEX Heat Pumps</title>
+  <meta name="description" content="Learn more about APEX Heating & Cooling Ltd. and our CleanBC certified heat pump specialists in Metro Vancouver.">
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+      color: #1f2933;
+      background: linear-gradient(180deg, #0e0f11 0%, #1f2933 45%, #f8fafc 45%);
+      line-height: 1.6;
+    }
+    header {
+      padding: 32px 20px 48px;
+      text-align: center;
+      color: #fff;
+    }
+    header h1 {
+      margin: 0 0 10px;
+      font-size: clamp(1.8rem, 3vw, 2.7rem);
+      letter-spacing: 0.02em;
+    }
+    header p {
+      margin: 0;
+      opacity: 0.85;
+    }
+    main {
+      background: #fff;
+      border-radius: 36px 36px 0 0;
+      padding: 40px 22px 72px;
+      max-width: 820px;
+      margin: -40px auto 0;
+      box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 24px;
+      font-weight: 600;
+      text-decoration: none;
+      color: #ff6b35;
+    }
+    h2 {
+      font-size: 1.7rem;
+      margin-top: 0;
+      color: #0f172a;
+    }
+    p {
+      margin-bottom: 16px;
+    }
+    .contact {
+      margin-top: 32px;
+      padding: 24px;
+      border-radius: 18px;
+      background: #f1f5f9;
+    }
+    .contact a {
+      color: #0e7490;
+      font-weight: 600;
+    }
+    footer {
+      text-align: center;
+      padding: 32px 16px 48px;
+      color: #e2e8f0;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>APEX Heat Pumps</h1>
+    <p>CleanBC registered, HPCN certified, and trusted by homeowners across Metro Vancouver.</p>
+  </header>
+  <main>
+    <a class="back-link" href="/">← Back to Home</a>
+    <h2>About Our Team</h2>
+    <p>APEX Heating & Cooling Ltd. is a locally owned HVAC contractor specializing in high-efficiency heat pump installations, gas furnace retrofits, and year-round maintenance. Our mission is to deliver reliable comfort, lower utility costs, and quieter homes for families throughout Metro Vancouver.</p>
+    <p>From the first site visit to post-installation support, you work directly with technicians who are licensed, insured, and CleanBC Home Performance Contractor Network (HPCN) certified. We design custom solutions for condos, townhomes, and single-family homes, ensuring your system qualifies for the maximum rebates available.</p>
+    <p>Every project includes careful load calculations, premium workmanship, and transparent pricing. We partner with leading manufacturers to provide ultra-efficient, cold-climate heat pumps that stand up to Pacific Northwest weather.</p>
+    <div class="contact">
+      <h3>Connect With Us</h3>
+      <p>Phone: <a href="tel:6044426711">604-442-6711</a></p>
+      <p>Email: <a href="mailto:info@apexheatpumps.ca">info@apexheatpumps.ca</a></p>
+      <p>Ready for a personalized proposal? Reach out today and we'll schedule a free consultation at your home.</p>
+    </div>
+  </main>
+  <footer>
+    © APEX Heating & Cooling Ltd. · Licensed & Insured · Serving Metro Vancouver
+  </footer>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>APEX Heat Pumps Blog</title>
+  <meta name="description" content="Latest updates and tips from APEX Heating & Cooling Ltd.">
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+      color: #1f2933;
+      background: #f8fafc;
+      line-height: 1.6;
+    }
+    header {
+      background: #0e0f11;
+      color: #fff;
+      padding: 28px 20px;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0 0 8px;
+      font-size: clamp(1.8rem, 3vw, 2.6rem);
+      letter-spacing: 0.03em;
+    }
+    header p {
+      margin: 0;
+      opacity: 0.8;
+    }
+    main {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 32px 20px 60px;
+      background: #fff;
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+      border-radius: 28px 28px 0 0;
+      margin-top: -32px;
+    }
+    a {
+      color: #ff6b35;
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 24px;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    h2 {
+      font-size: 1.6rem;
+      margin-top: 0;
+    }
+    footer {
+      text-align: center;
+      padding: 32px 16px;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>APEX Heat Pumps</h1>
+    <p>Updates, insights, and rebate news for Metro Vancouver homeowners.</p>
+  </header>
+  <main>
+    <a class="back-link" href="/">← Back to Home</a>
+    <h2>Blog Coming Soon</h2>
+    <p>We're building a library of practical guides to help you choose the right heat pump, understand CleanBC rebates, and keep your system operating efficiently. Check back soon for:</p>
+    <ul>
+      <li>Rebate breakdowns for the CleanBC and Canada Greener Homes programs</li>
+      <li>Maintenance tips to extend the life of your heat pump</li>
+      <li>Case studies from recent installations across Metro Vancouver</li>
+    </ul>
+    <p>Need expert advice today? Call <a href="tel:6044426711">604-442-6711</a> or email <a href="mailto:info@apexheatpumps.ca">info@apexheatpumps.ca</a>. Our HPCN-certified technicians are ready to help.</p>
+  </main>
+  <footer>
+    © APEX Heating & Cooling Ltd. | 604-442-6711 | info@apexheatpumps.ca
+  </footer>
+</body>
+</html>

--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,423 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Heat Pump Rebate Calculator | APEX Heat Pumps</title>
+  <meta name="description" content="Estimate your CleanBC, Canada Greener Homes, and municipal heat pump rebates with APEX Heating & Cooling's quick calculator.">
+  <style>
+    :root {
+      --apx-orange: #ff6b35;
+      --apx-dark: #0e0f11;
+      --apx-slate: #1f2933;
+      --apx-light: #f5f7fa;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+      color: var(--apx-slate);
+      background: #fff;
+      line-height: 1.6;
+    }
+    a {
+      color: inherit;
+    }
+    header {
+      background: var(--apx-dark);
+      color: #fff;
+      padding: 20px clamp(16px, 4vw, 48px);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.5rem, 2vw, 2rem);
+      letter-spacing: 0.02em;
+    }
+    header nav a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 6px 12px;
+      border-radius: 999px;
+      transition: background 0.2s ease;
+    }
+    header nav a:hover,
+    header nav a:focus {
+      background: rgba(255, 255, 255, 0.12);
+    }
+    main {
+      padding: clamp(24px, 5vw, 60px) clamp(16px, 6vw, 80px);
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 24px;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    .hero {
+      background: var(--apx-light);
+      padding: clamp(20px, 4vw, 36px);
+      border-radius: 20px;
+      box-shadow: 0 20px 40px rgba(14, 15, 17, 0.06);
+      margin-bottom: 32px;
+    }
+    .hero h2 {
+      margin-top: 0;
+      font-size: clamp(1.75rem, 3vw, 2.4rem);
+      color: var(--apx-dark);
+    }
+    .hero p {
+      margin-bottom: 0;
+      color: #52606d;
+    }
+    form {
+      background: #fff;
+      border-radius: 24px;
+      padding: clamp(20px, 4vw, 40px);
+      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 20px;
+    }
+    fieldset {
+      border: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 12px;
+    }
+    fieldset legend {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--apx-dark);
+      margin-bottom: 4px;
+    }
+    label {
+      display: grid;
+      gap: 6px;
+      font-weight: 600;
+      color: #334155;
+    }
+    input, select, textarea, button {
+      font: inherit;
+      padding: 12px 14px;
+      border: 1px solid #cbd5e1;
+      border-radius: 12px;
+    }
+    input:focus, select:focus, textarea:focus {
+      outline: 2px solid rgba(255, 107, 53, 0.35);
+      border-color: rgba(255, 107, 53, 0.35);
+    }
+    button[type="submit"] {
+      background: var(--apx-orange);
+      color: #fff;
+      font-weight: 700;
+      border: none;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    button[type="submit"]:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(255, 107, 53, 0.25);
+    }
+    .result-panel {
+      background: #fff9f6;
+      border: 1px solid rgba(255, 107, 53, 0.35);
+      border-radius: 20px;
+      padding: 24px;
+      display: grid;
+      gap: 16px;
+    }
+    .result-panel h3 {
+      margin: 0;
+      font-size: 1.4rem;
+      color: var(--apx-dark);
+    }
+    .result-grid {
+      display: grid;
+      gap: 12px;
+    }
+    .result-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+      padding-bottom: 8px;
+    }
+    .result-item strong {
+      font-size: 1.05rem;
+    }
+    .status-message {
+      font-weight: 600;
+      color: #0b7a35;
+      display: none;
+    }
+    .status-message.error {
+      color: #d14343;
+    }
+    .contact-card {
+      margin-top: 40px;
+      background: #0e0f11;
+      color: #fff;
+      border-radius: 24px;
+      padding: clamp(24px, 5vw, 36px);
+      display: grid;
+      gap: 12px;
+    }
+    .contact-card a {
+      color: #fff;
+      text-decoration: underline;
+      font-weight: 600;
+    }
+    footer {
+      text-align: center;
+      padding: 32px 16px 48px;
+      color: #64748b;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>APEX Heat Pumps</h1>
+    <nav aria-label="Calculator navigation">
+      <a href="/">Home</a>
+      <a href="tel:6044426711">Call 604-442-6711</a>
+      <a href="mailto:info@apexheatpumps.ca">Email Us</a>
+    </nav>
+  </header>
+
+  <main>
+    <a class="back-link" href="/">← Back to Home</a>
+
+    <section class="hero">
+      <h2>CleanBC & Canada Greener Homes Rebate Calculator</h2>
+      <p>Answer a few quick questions about your home and planned heat pump upgrade to estimate the rebates available from CleanBC, Canada Greener Homes, and municipal top-ups. You can send the results to our team for a personalized proposal.</p>
+    </section>
+
+    <form id="rebate-calculator" aria-describedby="calculator-status">
+      <input type="hidden" name="access_key" value="bfc609cd-6bf1-4d82-9c46-b739906dae10">
+      <fieldset>
+        <legend>Home Details</legend>
+        <label>
+          Your Name
+          <input type="text" name="name" placeholder="Jane Contractor" autocomplete="name" required>
+        </label>
+        <label>
+          Email Address
+          <input type="email" name="email" placeholder="you@example.com" autocomplete="email" required>
+        </label>
+        <label>
+          Phone Number
+          <input type="tel" name="phone" placeholder="604-000-0000" autocomplete="tel" required>
+        </label>
+        <label>
+          Project Address (City)
+          <input type="text" name="city" placeholder="Vancouver" autocomplete="address-level2">
+        </label>
+        <label>
+          Home Type
+          <select name="home_type" required>
+            <option value="detached">Detached House</option>
+            <option value="townhome">Townhome / Rowhouse</option>
+            <option value="condo">Condo / Apartment</option>
+          </select>
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Existing Heating</legend>
+        <label>
+          Current Primary Heating Source
+          <select name="existing_heating" required>
+            <option value="natural_gas">Natural Gas Furnace/Boiler</option>
+            <option value="electric_baseboards">Electric Baseboards</option>
+            <option value="oil_or_propane">Oil or Propane Furnace</option>
+          </select>
+        </label>
+        <label>
+          Are you a BC Hydro electricity customer?
+          <select name="bc_hydro" required>
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+          </select>
+        </label>
+        <label>
+          Household Income (before tax)
+          <select name="household_income" required>
+            <option value="under_117">Under $117,000</option>
+            <option value="117_180">$117,000 – $180,000</option>
+            <option value="over_180">Over $180,000</option>
+          </select>
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Heat Pump Upgrade</legend>
+        <label>
+          Heat Pump System Type
+          <select name="heat_pump_type" required>
+            <option value="central">Central Ducted Heat Pump</option>
+            <option value="cold_climate">Cold-Climate Ducted Heat Pump</option>
+            <option value="ductless_single">Ductless Single Zone</option>
+            <option value="ductless_multi">Ductless Multi-Zone (2+ heads)</option>
+          </select>
+        </label>
+        <label>
+          Estimated Installed Cost (after tax)
+          <input type="number" name="project_cost" min="0" step="500" placeholder="18000" required>
+        </label>
+        <label>
+          Additional Notes
+          <textarea name="notes" rows="3" placeholder="Any details we should know?"></textarea>
+        </label>
+      </fieldset>
+
+      <button type="submit">Calculate Rebates &amp; Send Results</button>
+      <p id="calculator-status" class="status-message" role="status" aria-live="polite"></p>
+    </form>
+
+    <section class="result-panel" aria-live="polite">
+      <h3>Estimated Rebates</h3>
+      <div class="result-grid" id="rebate-results">
+        <p>Fill out the form above and click "Calculate Rebates" to see your personalized estimate.</p>
+      </div>
+      <p><strong>Disclaimer:</strong> Rebates shown are estimates only. Final eligibility depends on program rules, pre-approval steps, and equipment specifications. Our HPCN-certified team will confirm exact rebate amounts for your installation.</p>
+    </section>
+
+    <aside class="contact-card">
+      <h3>Need help planning your project?</h3>
+      <p>We are CleanBC registered contractors serving Metro Vancouver. Call <a href="tel:6044426711">604-442-6711</a> or email <a href="mailto:info@apexheatpumps.ca">info@apexheatpumps.ca</a> for a free consultation.</p>
+    </aside>
+  </main>
+
+  <footer>
+    © APEX Heating & Cooling Ltd. · HPCN Certified · Serving Metro Vancouver
+  </footer>
+
+  <script>
+    const form = document.getElementById('rebate-calculator');
+    const resultsContainer = document.getElementById('rebate-results');
+    const statusMessage = document.getElementById('calculator-status');
+
+    const baseRebates = {
+      central: 5000,
+      cold_climate: 7000,
+      ductless_single: 3000,
+      ductless_multi: 4500
+    };
+
+    const programLabels = {
+      cleanbc: 'CleanBC Better Homes',
+      greenerHomes: 'Canada Greener Homes',
+      incomeTopUp: 'CleanBC Income Qualified',
+      municipal: 'Municipal / Regional Top-Up',
+      total: 'Total Estimated Rebates'
+    };
+
+    function formatCurrency(value) {
+      return new Intl.NumberFormat('en-CA', { style: 'currency', currency: 'CAD', maximumFractionDigits: 0 }).format(value);
+    }
+
+    function calculateRebates(data) {
+      const cleanBC = baseRebates[data.heat_pump_type] || 0;
+      const greenerHomes = cleanBC > 0 ? 5000 : 0;
+      let incomeTopUp = 0;
+      if (data.household_income === 'under_117') {
+        incomeTopUp = 6000;
+      } else if (data.household_income === '117_180') {
+        incomeTopUp = 2000;
+      }
+
+      let municipal = 0;
+      if (data.city && /north vancouver|richmond|burnaby|vancouver/i.test(data.city)) {
+        municipal = 2000;
+      }
+
+      if (data.existing_heating === 'electric_baseboards') {
+        municipal += 500;
+      }
+
+      if (data.bc_hydro === 'yes' && data.existing_heating !== 'electric_baseboards') {
+        municipal += 1000; // FortisBC & BC Hydro top-up combo estimate
+      }
+
+      const projectCost = Number.parseFloat(data.project_cost || '0');
+      const totalRebates = Math.min(cleanBC + greenerHomes + incomeTopUp + municipal, projectCost * 0.9);
+
+      return {
+        cleanbc: cleanBC,
+        greenerHomes,
+        incomeTopUp,
+        municipal,
+        total: totalRebates
+      };
+    }
+
+    function renderResults(breakdown, cost) {
+      resultsContainer.innerHTML = '';
+      Object.entries(breakdown).forEach(([key, value]) => {
+        const item = document.createElement('div');
+        item.className = 'result-item';
+        const label = document.createElement('span');
+        label.textContent = programLabels[key] || key;
+        const amount = document.createElement('strong');
+        amount.textContent = formatCurrency(value);
+        item.append(label, amount);
+        resultsContainer.appendChild(item);
+      });
+      const netCost = document.createElement('p');
+      const totalRebates = breakdown.total || 0;
+      if (cost > 0) {
+        const customerPortion = Math.max(cost - totalRebates, 0);
+        netCost.innerHTML = `<strong>Estimated customer investment:</strong> ${formatCurrency(customerPortion)} (before GST).`;
+        resultsContainer.appendChild(netCost);
+      }
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      statusMessage.style.display = 'none';
+      statusMessage.classList.remove('error');
+
+      const formData = new FormData(form);
+      const data = Object.fromEntries(formData.entries());
+
+      const breakdown = calculateRebates(data);
+      renderResults(breakdown, Number.parseFloat(data.project_cost || '0'));
+
+      formData.append('calculated_rebates', JSON.stringify(breakdown));
+
+      try {
+        statusMessage.textContent = 'Sending your estimate to our team…';
+        statusMessage.style.display = 'block';
+
+        const response = await fetch('https://api.web3forms.com/submit', {
+          method: 'POST',
+          body: formData
+        });
+
+        const result = await response.json();
+        if (result.success) {
+          statusMessage.textContent = 'Thanks! Your estimate was sent. We will follow up shortly.';
+          form.reset();
+        } else {
+          throw new Error(result.message || 'Submission failed');
+        }
+      } catch (error) {
+        console.error(error);
+        statusMessage.textContent = 'We calculated your rebates, but could not send the form. Please call 604-442-6711 or email info@apexheatpumps.ca.';
+        statusMessage.classList.add('error');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact APEX Heat Pumps</title>
+  <meta name="description" content="Get in touch with APEX Heating & Cooling Ltd. for heat pump installations, service, and 24/7 support in Metro Vancouver.">
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+      color: #0f172a;
+      background: #f1f5f9;
+      line-height: 1.6;
+    }
+    header {
+      background: radial-gradient(circle at top right, #ff6b35, #0e0f11);
+      color: #fff;
+      padding: 36px 20px 48px;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0 0 10px;
+      font-size: clamp(1.9rem, 3vw, 2.8rem);
+    }
+    header p {
+      margin: 0;
+      opacity: 0.85;
+    }
+    main {
+      max-width: 720px;
+      margin: -40px auto 0;
+      padding: 36px 22px 72px;
+      background: #fff;
+      border-radius: 32px 32px 0 0;
+      box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
+    }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 24px;
+      text-decoration: none;
+      font-weight: 600;
+      color: #ff6b35;
+    }
+    .contact-info {
+      display: grid;
+      gap: 16px;
+    }
+    .contact-info a {
+      color: #0e7490;
+      font-weight: 600;
+    }
+    footer {
+      text-align: center;
+      padding: 32px 16px 48px;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>APEX Heat Pumps</h1>
+    <p>Licensed HVAC technicians on call for Metro Vancouver homes and businesses.</p>
+  </header>
+  <main>
+    <a class="back-link" href="/">← Back to Home</a>
+    <h2>Contact Our Team</h2>
+    <p>We're ready to help with new installations, system upgrades, and emergency repairs. Reach us anytime and we'll respond within one business day.</p>
+    <div class="contact-info">
+      <p>Phone: <a href="tel:6044426711">604-442-6711</a></p>
+      <p>Email: <a href="mailto:info@apexheatpumps.ca">info@apexheatpumps.ca</a></p>
+      <p>Hours: 24/7 emergency support, standard appointments Monday to Saturday.</p>
+      <p>Service Area: Vancouver, Burnaby, Richmond, Surrey, Coquitlam, North Vancouver, and the Fraser Valley.</p>
+    </div>
+    <p>Prefer to meet in person? We can schedule an on-site assessment at your home to review equipment options, rebate eligibility, and financing.</p>
+  </main>
+  <footer>
+    © APEX Heating & Cooling Ltd. | 604-442-6711 | info@apexheatpumps.ca
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a rebate calculator page with Web3Forms submission and dynamic rebate estimate breakdown
- add simple blog, about, and contact placeholder pages with contact information and home links

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e15a8ceb94832db7f7a32e3d2dd6fd