### PR TITLE
Add interactive rebate calculator landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
   <nav class="apx-nav" aria-label="Primary">
     <a href="/">Home</a>
     <a href="/services">Services</a>
-    <a href="/rebates">Rebates</a>
+    <a href="rebate-calculator.html">Rebates</a>
     <a href="/contact">Contact</a>
   </nav>
   <a class="apx-call-desktop" href="tel:6044426711">Call for Free Quote: 604-442-6711</a>
@@ -71,7 +71,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
 
 <a class="apx-call-fab" href="tel:6044426711" aria-label="Call now">📞 CALL NOW</a>
 
-<aside class="apx-contact">
+<aside class="apx-contact" id="contact">
   <button class="apx-contact__toggle" aria-controls="apx-contact-form" aria-expanded="false">Get Free Quote</button>
   <form id="apx-contact-form" class="apx-contact__form" action="/submit" method="post" novalidate>
     <input type="text" name="name" placeholder="Your Name" required>

--- a/rebate-calculator.html
+++ b/rebate-calculator.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rebate Calculator - Apex Heating & Cooling</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #dbeafe, #dcfce7);
+            min-height: 100vh;
+            padding: 20px;
+        }
+        .calculator-container {
+            max-width: 700px;
+            margin: 40px auto;
+            background: white;
+            border-radius: 20px;
+            padding: 40px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+        }
+        h1 {
+            font-size: 36px;
+            color: #1e3a8a;
+            margin-bottom: 10px;
+            text-align: center;
+        }
+        .subtitle {
+            text-align: center;
+            color: #6b7280;
+            font-size: 18px;
+            margin-bottom: 40px;
+        }
+        .question { margin-bottom: 30px; }
+        .question-label {
+            font-size: 18px;
+            font-weight: 700;
+            color: #1e3a8a;
+            margin-bottom: 15px;
+            display: block;
+        }
+        .radio-group {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .radio-option {
+            display: flex;
+            align-items: center;
+            padding: 15px 20px;
+            border: 2px solid #bfdbfe;
+            border-radius: 10px;
+            cursor: pointer;
+            transition: all 0.3s;
+            background: white;
+        }
+        .radio-option:hover {
+            border-color: #16a34a;
+            background: #f0fdf4;
+        }
+        .radio-option input {
+            margin-right: 12px;
+            width: 20px;
+            height: 20px;
+            cursor: pointer;
+            accent-color: #16a34a;
+        }
+        .input-field {
+            width: 100%;
+            padding: 15px;
+            border: 2px solid #bfdbfe;
+            border-radius: 10px;
+            font-size: 16px;
+            margin-bottom: 15px;
+        }
+        .input-field:focus {
+            outline: none;
+            border-color: #16a34a;
+            box-shadow: 0 0 0 3px rgba(22,163,74,0.1);
+        }
+        .submit-btn {
+            width: 100%;
+            padding: 18px;
+            background: linear-gradient(135deg, #16a34a, #15803d);
+            color: white;
+            border: none;
+            border-radius: 12px;
+            font-size: 20px;
+            font-weight: 700;
+            cursor: pointer;
+            margin-top: 20px;
+            transition: all 0.3s;
+        }
+        .submit-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 30px rgba(22,163,74,0.3);
+        }
+        .submit-btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+        .result { display: none; }
+        .result.show {
+            display: block;
+            animation: slideIn 0.5s ease;
+        }
+        @keyframes slideIn {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .result-header {
+            background: linear-gradient(135deg, #16a34a, #15803d);
+            color: white;
+            padding: 30px;
+            border-radius: 15px;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .rebate-amount {
+            font-size: 56px;
+            font-weight: 900;
+            margin: 20px 0;
+        }
+        .result-section {
+            background: linear-gradient(135deg, #eff6ff, #f0fdf4);
+            padding: 25px;
+            border-radius: 12px;
+            margin-bottom: 20px;
+            border: 2px solid #bfdbfe;
+        }
+        .result-section h3 {
+            color: #1e3a8a;
+            margin-bottom: 15px;
+        }
+        .result-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 12px 0;
+            border-bottom: 1px solid #dbeafe;
+        }
+        .cta-btns {
+            display: flex;
+            gap: 15px;
+            margin-top: 30px;
+        }
+        .cta-btn {
+            flex: 1;
+            padding: 18px;
+            border-radius: 10px;
+            text-align: center;
+            text-decoration: none;
+            font-weight: 700;
+            transition: all 0.3s;
+        }
+        .cta-primary {
+            background: #16a34a;
+            color: white;
+        }
+        .cta-secondary {
+            background: white;
+            color: #16a34a;
+            border: 2px solid #16a34a;
+        }
+        @media (max-width: 768px) {
+            .calculator-container { padding: 30px 20px; }
+            .rebate-amount { font-size: 42px; }
+            .cta-btns { flex-direction: column; }
+        }
+    </style>
+</head>
+<body>
+    <div class="calculator-container">
+        <a href="index.html" style="color: #16a34a; font-weight: 600; text-decoration: none; margin-bottom: 20px; display: inline-block;">← Back to Home</a>
+        <h1>Calculate Your Rebate</h1>
+        <p class="subtitle">Answer 6 quick questions • Takes 2 minutes</p>
+        <div id="calc-form">
+            <div class="question">
+                <label class="question-label">1. How many adults (18+) live in your household?</label>
+                <div class="radio-group">
+                    <label class="radio-option" for="adults-1">
+                        <input type="radio" name="adults" value="1" id="adults-1" required>
+                        <span>1 adult</span>
+                    </label>
+                    <label class="radio-option" for="adults-2">
+                        <input type="radio" name="adults" value="2" id="adults-2">
+                        <span>2 adults</span>
+                    </label>
+                    <label class="radio-option" for="adults-3">
+                        <input type="radio" name="adults" value="3" id="adults-3">
+                        <span>3+ adults</span>
+                    </label>
+                </div>
+            </div>
+            <div class="question">
+                <label class="question-label">2. Combined household income? (Before taxes)</label>
+                <div class="radio-group">
+                    <label class="radio-option" for="income-1">
+                        <input type="radio" name="income" value="level1" id="income-1" required>
+                        <span>Under $48,000/year</span>
+                    </label>
+                    <label class="radio-option" for="income-2">
+                        <input type="radio" name="income" value="level2" id="income-2">
+                        <span>$48,000 - $78,000/year</span>
+                    </label>
+                    <label class="radio-option" for="income-3">
+                        <input type="radio" name="income" value="level3" id="income-3">
+                        <span>$78,000 - $93,000/year</span>
+                    </label>
+                    <label class="radio-option" for="income-over">
+                        <input type="radio" name="income" value="over" id="income-over">
+                        <span>Over $93,000/year</span>
+                    </label>
+                </div>
+            </div>
+            <div class="question">
+                <label class="question-label" for="heating">3. Current heating system?</label>
+                <select class="input-field" id="heating" required>
+                    <option value="">Select type</option>
+                    <option value="gas">Natural gas furnace</option>
+                    <option value="electric">Electric baseboard/furnace</option>
+                    <option value="oil">Oil furnace</option>
+                    <option value="propane">Propane</option>
+                    <option value="wood">Wood stove</option>
+                    <option value="other">Other</option>
+                </select>
+            </div>
+            <div class="question">
+                <label class="question-label">4. Your contact info (for detailed quote)</label>
+                <input type="text" class="input-field" id="firstname" placeholder="First Name *" required>
+                <input type="text" class="input-field" id="lastname" placeholder="Last Name *" required>
+                <input type="tel" class="input-field" id="phone" placeholder="Phone Number *" required>
+                <input type="email" class="input-field" id="email" placeholder="Email *" required>
+                <input type="text" class="input-field" id="city" placeholder="City *" required>
+            </div>
+            <div style="display: flex; align-items: start; gap: 10px; margin: 20px 0;">
+                <input type="checkbox" id="consent" checked style="margin-top: 4px;">
+                <label for="consent" style="font-size: 14px; color: #6b7280;">
+                    Yes, I'd like to receive information about heat pump rebates and energy savings tips
+                </label>
+            </div>
+            <button class="submit-btn" onclick="submitCalculator()" id="submit-btn">
+                Calculate My Rebate →
+            </button>
+            <p style="text-align: center; font-size: 12px; color: #9ca3af; margin-top: 15px;">
+                By submitting, you agree to be contacted by Apex Heating & Cooling Ltd.
+            </p>
+        </div>
+        <div id="result" class="result" aria-live="polite">
+            <div class="result-header">
+                <div style="font-size: 50px; margin-bottom: 15px;" aria-hidden="true">🎉</div>
+                <h2 id="result-title" style="font-size: 32px; margin-bottom: 15px;">Great News!</h2>
+                <div id="result-subtitle" style="font-size: 18px; margin-bottom: 10px;"></div>
+                <div class="rebate-amount" id="rebate-amount">Up to $24,500</div>
+            </div>
+            <div class="result-section">
+                <h3>💰 Your Estimated Rebates</h3>
+                <div class="result-item">
+                    <span>Heat Pump System:</span>
+                    <strong id="system-rebate">Up to $19,000</strong>
+                </div>
+                <div class="result-item">
+                    <span>Electrical Upgrades:</span>
+                    <strong id="electrical-rebate">Up to $5,000</strong>
+                </div>
+                <div class="result-item" style="border-top: 2px solid #16a34a; padding-top: 15px; margin-top: 10px;">
+                    <span style="font-weight: 700;">Total Rebates:</span>
+                    <strong style="color: #16a34a; font-size: 20px;" id="total-rebate">$24,500</strong>
+                </div>
+            </div>
+            <div class="result-section">
+                <h3>💵 Your Estimated Costs</h3>
+                <div class="result-item">
+                    <span>Typical project cost:</span>
+                    <strong>$18,000 - $22,000</strong>
+                </div>
+                <div class="result-item">
+                    <span>Minus rebates:</span>
+                    <strong style="color: #16a34a;" id="minus-rebate">-$24,500</strong>
+                </div>
+                <div class="result-item" style="border-top: 2px solid #16a34a; padding-top: 15px; margin-top: 10px;">
+                    <span style="font-weight: 700;">Your out-of-pocket:</span>
+                    <strong style="color: #16a34a; font-size: 20px;" id="out-of-pocket">$0 - $500</strong>
+                </div>
+            </div>
+            <div style="background: #fef3c7; padding: 20px; border-radius: 12px; border-left: 4px solid #f59e0b; margin-bottom: 20px;">
+                <p style="font-weight: 700; color: #92400e; margin-bottom: 8px;">
+                    ⚡ Annual Savings: <span style="color: #16a34a;">~$1,500/year</span>
+                </p>
+                <p style="font-size: 14px; color: #92400e;">Payback: <span id="payback">Immediate</span></p>
+            </div>
+            <div class="cta-btns">
+                <a href="tel:6044426711" class="cta-btn cta-primary">📞 Call Now: 604-442-6711</a>
+                <a href="index.html#contact" class="cta-btn cta-secondary">Book Assessment</a>
+            </div>
+            <p style="text-align: center; margin-top: 20px; color: #6b7280; font-size: 14px;">
+                ✅ Email sent! Check your inbox for your detailed rebate estimate.
+            </p>
+        </div>
+    </div>
+    <script>
+    async function submitCalculator() {
+        const adults = document.querySelector('input[name="adults"]:checked');
+        const income = document.querySelector('input[name="income"]:checked');
+        const heating = document.getElementById('heating').value;
+        const firstname = document.getElementById('firstname').value.trim();
+        const lastname = document.getElementById('lastname').value.trim();
+        const phone = document.getElementById('phone').value.trim();
+        const email = document.getElementById('email').value.trim();
+        const city = document.getElementById('city').value.trim();
+        if (!adults || !income || !heating || !firstname || !lastname || !phone || !email || !city) {
+            alert('Please answer all questions and fill in your contact information.');
+            return;
+        }
+        const submitBtn = document.getElementById('submit-btn');
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Calculating...';
+        const level = income.value;
+        let systemRebate;
+        let electricalRebate;
+        let totalRebate;
+        let outOfPocket;
+        let payback;
+        let title;
+        let subtitle;
+        if (level === 'level1') {
+            systemRebate = '$19,000';
+            electricalRebate = '$5,000';
+            totalRebate = '$24,500';
+            outOfPocket = '$0 - $500';
+            payback = 'Immediate (covered by rebates)';
+            title = 'Great News!';
+            subtitle = 'You Qualify For Up To $24,500 in Rebates';
+        } else if (level === 'level2') {
+            systemRebate = '$16,000';
+            electricalRebate = '$3,500';
+            totalRebate = '$19,500';
+            outOfPocket = '$0 - $2,500';
+            payback = '1-2 years';
+            title = 'Excellent!';
+            subtitle = 'You Qualify For Up To $19,500 in Rebates';
+        } else if (level === 'level3' && (heating === 'gas' || heating === 'oil' || heating === 'propane')) {
+            systemRebate = '$16,000';
+            electricalRebate = 'Not included';
+            totalRebate = '$16,000';
+            outOfPocket = '$2,000 - $6,000';
+            payback = '2-4 years';
+            title = 'Good News!';
+            subtitle = 'You Qualify For Up To $16,000 in Rebates';
+        } else {
+            systemRebate = '$4,000';
+            electricalRebate = 'May qualify separately';
+            totalRebate = '$4,000+';
+            outOfPocket = '$14,000 - $18,000';
+            payback = '9-12 years';
+            title = 'You May Still Qualify';
+            subtitle = 'Standard CleanBC Program Available';
+        }
+        const formData = new FormData();
+        formData.append('access_key', 'YOUR_ACCESS_KEY_HERE');
+        formData.append('subject', '🔥 New Heat Pump Lead - ' + totalRebate + ' Rebate');
+        formData.append('from_name', 'Apex Website Calculator');
+        formData.append('name', firstname + ' ' + lastname);
+        formData.append('email', email);
+        formData.append('phone', phone);
+        formData.append('city', city);
+        formData.append('household_adults', adults.value);
+        formData.append('income_level', level);
+        formData.append('heating_type', heating);
+        formData.append('estimated_rebate', totalRebate);
+        formData.append('out_of_pocket', outOfPocket);
+        formData.append('payback_period', payback);
+        formData.append('message', `\nNew Rebate Calculator Submission\n\nCONTACT INFO:\nName: ${firstname} ${lastname}\nPhone: ${phone}\nEmail: ${email}\nCity: ${city}\n\nHOUSEHOLD INFO:\nAdults: ${adults.value}\nIncome Level: ${level}\nCurrent Heating: ${heating}\n\nREBATE DETAILS:\nEstimated Rebate: ${totalRebate}\nOut-of-Pocket: ${outOfPocket}\nPayback Period: ${payback}\n\nNEXT STEPS:\n📞 Call within 24 hours: ${phone}\n📧 Email: ${email}\n\nSubmitted: ${new Date().toLocaleString()}\n`);
+        try {
+            const response = await fetch('https://api.web3forms.com/submit', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await response.json();
+            if (data.success) {
+                showResults(title, subtitle, systemRebate, electricalRebate, totalRebate, outOfPocket, payback);
+            } else {
+                console.error('Submission failed:', data);
+                alert('There was an issue submitting. Please call us at 604-442-6711');
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Calculate My Rebate →';
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert('There was an issue submitting. Please call us at 604-442-6711');
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Calculate My Rebate →';
+        }
+    }
+    function showResults(title, subtitle, systemRebate, electricalRebate, totalRebate, outOfPocket, payback) {
+        document.getElementById('calc-form').style.display = 'none';
+        document.getElementById('result-title').textContent = title;
+        document.getElementById('result-subtitle').textContent = subtitle;
+        document.getElementById('rebate-amount').textContent = 'Up to ' + totalRebate;
+        document.getElementById('system-rebate').textContent = 'Up to ' + systemRebate;
+        document.getElementById('electrical-rebate').textContent = 'Up to ' + electricalRebate;
+        document.getElementById('total-rebate').textContent = totalRebate;
+        document.getElementById('minus-rebate').textContent = '-' + totalRebate;
+        document.getElementById('out-of-pocket').textContent = outOfPocket;
+        document.getElementById('payback').textContent = payback;
+        document.getElementById('result').classList.add('show');
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated rebate-calculator page with styled questionnaire, rebate logic, and Web3Forms submission payload
- include household adult count in the submitted data and enhance the confirmation view messaging
- link the site navigation and contact anchor to the new calculator page for easier access

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e0fa097ca4832d82f2da30b480e1ba