### PR TITLE
Add Web3Forms-enabled rebate calculator

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,456 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Heat Pump Rebate Calculator | APEX</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --apx-orange: #ff6b35;
+      --apx-dark: #0e0f11;
+      --apx-sage: #eff7f2;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #fafafa;
+      color: #222;
+      line-height: 1.5;
+    }
+
+    header {
+      background: #fff;
+      border-bottom: 1px solid #eee;
+      padding: 20px clamp(16px, 4vw, 48px);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    header .logo {
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-decoration: none;
+      color: var(--apx-dark);
+    }
+
+    header nav a {
+      margin-left: 1.2rem;
+      font-weight: 600;
+      text-decoration: none;
+      color: #374151;
+    }
+
+    main {
+      padding: clamp(24px, 5vw, 72px);
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .hero {
+      text-align: center;
+      margin-bottom: clamp(32px, 5vw, 72px);
+    }
+
+    .hero h1 {
+      font-size: clamp(1.9rem, 4vw, 3rem);
+      margin-bottom: 0.25rem;
+    }
+
+    .hero p {
+      margin: 0.25rem 0 0;
+      color: #4b5563;
+      font-size: 1.1rem;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 18px;
+      padding: clamp(20px, 4vw, 40px);
+      box-shadow: 0 20px 45px -28px rgba(13, 27, 42, 0.35);
+    }
+
+    form {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 18px 24px;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 6px;
+      color: #111827;
+    }
+
+    input[type="text"],
+    input[type="email"],
+    input[type="tel"],
+    select,
+    textarea {
+      width: 100%;
+      padding: 12px;
+      border-radius: 10px;
+      border: 1px solid #d1d5db;
+      font-size: 1rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
+
+    input:focus,
+    select:focus,
+    textarea:focus {
+      outline: 3px solid rgba(255, 107, 53, 0.25);
+      border-color: var(--apx-orange);
+      box-shadow: 0 0 0 4px rgba(255, 107, 53, 0.15);
+    }
+
+    .fieldset {
+      border: 1px solid #e5e7eb;
+      border-radius: 14px;
+      padding: 16px 18px;
+      background: var(--apx-sage);
+    }
+
+    .fieldset legend {
+      font-weight: 700;
+      padding: 0 6px;
+      color: var(--apx-dark);
+    }
+
+    .option-row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      margin-top: 6px;
+      font-size: 0.95rem;
+    }
+
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
+    .honeypot {
+      position: absolute;
+      left: -9999px;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .submit-row {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      align-items: center;
+    }
+
+    button[type="submit"] {
+      background: var(--apx-orange);
+      color: #fff;
+      border: none;
+      padding: 14px 26px;
+      border-radius: 12px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    button[type="submit"]:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px -16px rgba(255, 107, 53, 0.5);
+    }
+
+    .status {
+      margin-top: 10px;
+      font-size: 0.95rem;
+    }
+
+    .status.success {
+      color: #047857;
+    }
+
+    .status.error {
+      color: #b91c1c;
+    }
+
+    .results {
+      background: #fff8f4;
+      border: 1px solid rgba(255, 107, 53, 0.2);
+      border-radius: 12px;
+      padding: 18px;
+      margin-top: 18px;
+      display: none;
+    }
+
+    .results h3 {
+      margin-top: 0;
+    }
+
+    @media (max-width: 640px) {
+      header nav {
+        display: none;
+      }
+
+      form {
+        grid-template-columns: 1fr;
+      }
+
+      .submit-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      button[type="submit"] {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/" class="logo">APEX Heat Pumps</a>
+    <nav aria-label="Primary navigation">
+      <a href="/">Home</a>
+      <a href="/services">Services</a>
+      <a href="/rebates">Rebates</a>
+      <a href="/contact">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <h1>CleanBC Heat Pump Rebate Calculator</h1>
+      <p>Instant estimate of your eligible rebates. We’ll email the details right away.</p>
+    </section>
+
+    <section class="card" aria-label="Heat pump rebate calculator">
+      <form id="rebate-calculator" novalidate>
+        <div class="full-width">
+          <label for="firstname">First Name</label>
+          <input id="firstname" name="firstname" type="text" autocomplete="given-name" required>
+        </div>
+
+        <div class="full-width">
+          <label for="lastname">Last Name</label>
+          <input id="lastname" name="lastname" type="text" autocomplete="family-name" required>
+        </div>
+
+        <div>
+          <label for="phone">Phone</label>
+          <input id="phone" name="phone" type="tel" autocomplete="tel" inputmode="tel" pattern="[0-9\s\-()+]+" required>
+        </div>
+
+        <div>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" autocomplete="email" required>
+        </div>
+
+        <div class="full-width">
+          <label for="city">City</label>
+          <input id="city" name="city" type="text" autocomplete="address-level2" required>
+        </div>
+
+        <fieldset class="fieldset full-width">
+          <legend>Household income</legend>
+          <label class="option-row"><input type="radio" name="income" value="level1" checked> Under $117,000</label>
+          <label class="option-row"><input type="radio" name="income" value="level2"> $117,001 - $208,000</label>
+          <label class="option-row"><input type="radio" name="income" value="level3"> Above $208,001</label>
+        </fieldset>
+
+        <fieldset class="fieldset full-width">
+          <legend>Current heating system</legend>
+          <label class="option-row"><input type="radio" name="currentHeating" value="gas" checked> Natural Gas Furnace or Boiler</label>
+          <label class="option-row"><input type="radio" name="currentHeating" value="electric"> Baseboards / Electric Furnace</label>
+          <label class="option-row"><input type="radio" name="currentHeating" value="oil"> Oil or Propane</label>
+        </fieldset>
+
+        <div class="full-width">
+          <label for="notes">Anything else we should know?</label>
+          <textarea id="notes" name="notes" placeholder="Square footage, timeline, pain points..."></textarea>
+        </div>
+
+        <input type="text" name="website" class="honeypot" tabindex="-1" autocomplete="off">
+
+        <div class="submit-row full-width">
+          <button type="submit">Calculate My Rebate</button>
+          <p class="status" id="status" role="status" aria-live="polite"></p>
+        </div>
+      </form>
+
+      <aside class="results" id="results" aria-live="polite" tabindex="-1">
+        <h3>Estimated rebate</h3>
+        <p><strong>Total rebate:</strong> <span id="total-rebate">$0</span></p>
+        <p><strong>Out of pocket:</strong> <span id="out-of-pocket">$0</span></p>
+        <p><strong>Payback period:</strong> <span id="payback">–</span></p>
+      </aside>
+    </section>
+  </main>
+
+  <template id="email-template">
+    🎯 HIGH PRIORITY LEAD
+
+    Customer: {{firstname}} {{lastname}}
+    📞 {{phone}}
+    📧 {{email}}
+    📍 {{city}}
+
+    💰 Qualifies for: {{totalRebate}}
+    💵 Out of pocket: {{outOfPocket}}
+
+    ⏰ Call ASAP!
+  </template>
+
+  <script>
+    const form = document.getElementById('rebate-calculator');
+    const statusEl = document.getElementById('status');
+    const resultsPanel = document.getElementById('results');
+    const totalRebateEl = document.getElementById('total-rebate');
+    const outOfPocketEl = document.getElementById('out-of-pocket');
+    const paybackEl = document.getElementById('payback');
+    const emailTemplate = document.getElementById('email-template');
+
+    const ACCESS_KEY = 'YOUR_ACCESS_KEY_HERE'; // Replace with your Web3Forms access key
+
+    const rebateConfig = {
+      level1: { gas: 24500, electric: 14000, oil: 24500 },
+      level2: { gas: 15500, electric: 12000, oil: 15500 },
+      level3: { gas: 7000, electric: 5000, oil: 7000 }
+    };
+
+    const outOfPocketMap = {
+      level1: '$0 - $500',
+      level2: '$2,000 - $4,000',
+      level3: '$6,000 - $9,500'
+    };
+
+    const paybackMap = {
+      level1: 'Immediate',
+      level2: '1 - 3 years',
+      level3: '3 - 5 years'
+    };
+
+    const formatCurrency = (value) => new Intl.NumberFormat('en-CA', {
+      style: 'currency',
+      currency: 'CAD',
+      maximumFractionDigits: 0
+    }).format(value);
+
+    const renderTemplate = (template, data) => {
+      return template.innerHTML.replace(/{{(\w+)}}/g, (_, key) => data[key] ?? '');
+    };
+
+    const buildEmailSubject = (firstname, totalRebate) => `🔥 NEW LEAD: ${firstname} - ${totalRebate}`;
+
+    const buildEmailMessage = (data) => renderTemplate(emailTemplate, data);
+
+    const setStatus = (message, type = '') => {
+      statusEl.textContent = message;
+      statusEl.className = `status ${type}`.trim();
+    };
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      if (!ACCESS_KEY || ACCESS_KEY === 'YOUR_ACCESS_KEY_HERE') {
+        setStatus('Please configure your Web3Forms access key before going live.', 'error');
+        return;
+      }
+
+      const formData = new FormData(form);
+      if (formData.get('website')) {
+        setStatus('Submission blocked. Try again without additional fields.', 'error');
+        return;
+      }
+
+      const incomeLevel = formData.get('income');
+      const heating = formData.get('currentHeating');
+      const totalRebateValue = rebateConfig?.[incomeLevel]?.[heating] ?? 0;
+      const totalRebate = formatCurrency(totalRebateValue);
+      const outOfPocket = outOfPocketMap[incomeLevel] ?? '$0';
+      const payback = paybackMap[incomeLevel] ?? 'Contact us for details';
+
+      totalRebateEl.textContent = totalRebate;
+      outOfPocketEl.textContent = outOfPocket;
+      paybackEl.textContent = payback;
+      resultsPanel.style.display = 'block';
+
+      const payload = new FormData();
+      payload.append('access_key', ACCESS_KEY);
+      payload.append('from_name', 'APEX Heat Pumps Calculator');
+      payload.append('replyto', formData.get('email'));
+      payload.append('firstname', formData.get('firstname'));
+      payload.append('lastname', formData.get('lastname'));
+      payload.append('phone', formData.get('phone'));
+      payload.append('email', formData.get('email'));
+      payload.append('city', formData.get('city'));
+      payload.append('income', incomeLevel);
+      payload.append('current_heating', heating);
+      payload.append('estimated_rebate', totalRebate);
+      payload.append('out_of_pocket', outOfPocket);
+      payload.append('payback_period', payback);
+      payload.append('notes', formData.get('notes') ?? '');
+
+      const emailData = {
+        firstname: formData.get('firstname'),
+        lastname: formData.get('lastname'),
+        phone: formData.get('phone'),
+        email: formData.get('email'),
+        city: formData.get('city'),
+        totalRebate,
+        outOfPocket
+      };
+
+      payload.append('subject', buildEmailSubject(emailData.firstname, totalRebate));
+      payload.append('message', buildEmailMessage(emailData));
+
+      setStatus('Calculating your rebates...');
+
+      try {
+        const response = await fetch('https://api.web3forms.com/submit', {
+          method: 'POST',
+          body: payload
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          setStatus('Success! Check your email for the rebate summary.', 'success');
+          form.reset();
+          resultsPanel.focus?.();
+        } else {
+          throw new Error(result.message || 'Submission failed');
+        }
+      } catch (error) {
+        console.error(error);
+        setStatus('We could not submit the form. Please call 604-442-6711 or email info@apexheatpumps.ca.', 'error');
+      }
+    });
+  </script>
+
+  <!--
+    🔧 Setup Instructions
+    1. Replace ACCESS_KEY with your Web3Forms access key.
+    2. Test by submitting the form with sample data.
+    3. Configure optional auto-responder and webhooks via Web3Forms dashboard.
+    4. To enable reCAPTCHA, add the widget inside the form and include the script tag.
+  -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone rebate calculator page with responsive layout and CleanBC-focused form fields
- integrate Web3Forms submission logic with configurable email subject, message, and rebate calculations
- document follow-up configuration steps directly in the page for quick setup

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e0fb698e14832db7328410c4def5bc