### PR TITLE
Update services navigation links to static page

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const navLinks = [
   { href: '/', label: 'Home' },
-  { href: '/services', label: 'Services' },
+  { href: 'services.html', label: 'Services' },
   { href: '/rebates', label: 'Rebates' },
   { href: '/contact', label: 'Contact' },
 ];

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
   <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav class="apx-nav" aria-label="Primary">
     <a href="/">Home</a>
-    <a href="/services">Services</a>
+    <a href="services.html">Services</a>
     <a href="rebate-calculator.html">Rebates</a>
     <a href="/contact">Contact</a>
   </nav>

--- a/quote.html
+++ b/quote.html
@@ -28,7 +28,7 @@ footer.apx-footer{margin-top:56px;padding:24px 16px;text-align:center;color:#666
   <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
     <a href="/">Home</a>
-    <a href="/services">Services</a>
+    <a href="services.html">Services</a>
     <a href="/rebates">Rebates</a>
     <a href="/contact">Contact</a>
   </nav>

--- a/rebates.html
+++ b/rebates.html
@@ -28,7 +28,7 @@ footer.apx-footer{margin-top:56px;padding:24px 16px;border-top:1px solid #ececec
   <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
     <a href="/">Home</a>
-    <a href="/services">Services</a>
+    <a href="services.html">Services</a>
     <a href="/rebates" aria-current="page">Rebates</a>
     <a href="/contact">Contact</a>
   </nav>

--- a/services.html
+++ b/services.html
@@ -26,7 +26,7 @@ footer.apx-footer{margin-top:48px;padding:24px 16px;font-size:.9rem;color:#666;t
   <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
     <a href="/">Home</a>
-    <a href="/services" aria-current="page">Services</a>
+    <a href="services.html" aria-current="page">Services</a>
     <a href="/rebates">Rebates</a>
     <a href="/contact">Contact</a>
   </nav>


### PR DESCRIPTION
## Summary
- update static HTML navigation to link to services.html instead of the old /services path
- align the shared React navigation component to the same services.html destination for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2706dc58c832d846da9dd6f542511