### PR TITLE
Add About link to primary navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
   <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav class="apx-nav" aria-label="Primary">
     <a href="/">Home</a>
+    <a href="about.html">About</a>
     <a href="services.html">Services</a>
     <a href="rebate-calculator.html">Rebates</a>
     <a href="/contact">Contact</a>


### PR DESCRIPTION
## Summary
- add a primary navigation link to the About page so visitors can find company information easily

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27230f4fc832daeebea1e5886d8e4