### PR TITLE
Align header navigation links with static HTML pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,14 +49,14 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
 <body>
 
 <header class="apx-header">
-  <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+  <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav class="apx-nav" aria-label="Primary">
-    <a href="/">Home</a>
+    <a href="index.html">Home</a>
     <a href="about.html">About</a>
     <!-- Updated Services link to point to the correct file -->
     <a href="services.html">Services</a>
-    <a href="rebate-calculator.html">Rebates</a>
-    <a href="/contact">Contact</a>
+    <a href="rebates.html">Rebates</a>
+    <a href="contact.html">Contact</a>
   </nav>
   <a class="apx-call-desktop" href="tel:6044426711">Call for Free Quote: 604-442-6711</a>
 </header>

--- a/quote.html
+++ b/quote.html
@@ -25,12 +25,13 @@ footer.apx-footer{margin-top:56px;padding:24px 16px;text-align:center;color:#666
 </head>
 <body>
 <header class="apx-header">
-  <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+  <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
-    <a href="/">Home</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
     <a href="services.html">Services</a>
-    <a href="/rebates">Rebates</a>
-    <a href="/contact">Contact</a>
+    <a href="rebates.html">Rebates</a>
+    <a href="contact.html">Contact</a>
   </nav>
 </header>
 <main>

--- a/rebates.html
+++ b/rebates.html
@@ -25,12 +25,13 @@ footer.apx-footer{margin-top:56px;padding:24px 16px;border-top:1px solid #ececec
 </head>
 <body>
 <header class="apx-header">
-  <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+  <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
-    <a href="/">Home</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
     <a href="services.html">Services</a>
-    <a href="/rebates" aria-current="page">Rebates</a>
-    <a href="/contact">Contact</a>
+    <a href="rebates.html" aria-current="page">Rebates</a>
+    <a href="contact.html">Contact</a>
   </nav>
 </header>
 <main>

--- a/services.html
+++ b/services.html
@@ -23,12 +23,13 @@ footer.apx-footer{margin-top:48px;padding:24px 16px;font-size:.9rem;color:#666;t
 </head>
 <body>
 <header class="apx-header">
-  <a href="/" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+  <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
   <nav aria-label="Primary navigation">
-    <a href="/">Home</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
     <a href="services.html" aria-current="page">Services</a>
-    <a href="/rebates">Rebates</a>
-    <a href="/contact">Contact</a>
+    <a href="rebates.html">Rebates</a>
+    <a href="contact.html">Contact</a>
   </nav>
 </header>
 <main>


### PR DESCRIPTION
## Summary
- update the shared header navigation links to reference the .html pages across the home, services, rebates, and quote layouts
- keep the aria-current attribute on the active page while adding the About link where it was missing

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68e274a497f4832daaa71ea7805c6d1d