### PR TITLE
Add shared header navigation to about and contact pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,8 @@
   <title>About APEX Heat Pumps</title>
   <meta name="description" content="Learn more about APEX Heating & Cooling Ltd. and our CleanBC certified heat pump specialists in Metro Vancouver.">
   <style>
+    :root { --apx-orange: #ff6b35; --apx-dark: #0e0f11; }
+    * { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: system-ui, -apple-system, Segoe UI, sans-serif;
@@ -13,17 +15,45 @@
       background: linear-gradient(180deg, #0e0f11 0%, #1f2933 45%, #f8fafc 45%);
       line-height: 1.6;
     }
-    header {
+    a { color: inherit; text-decoration: none; }
+    .apx-header {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      justify-content: space-between;
+      padding: 12px 16px;
+      border-bottom: 1px solid #eee;
+      position: sticky;
+      top: 0;
+      background: #fff;
+      z-index: 100;
+    }
+    .apx-header .logo { font-weight: 800; color: var(--apx-dark); }
+    .apx-nav a { margin: 0 8px; color: var(--apx-dark); }
+    .apx-nav a[aria-current="page"] { font-weight: 700; text-decoration: underline; }
+    .apx-call-desktop {
+      background: var(--apx-orange);
+      color: #fff;
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-weight: 600;
+      display: none;
+      white-space: nowrap;
+    }
+    @media (min-width: 900px) {
+      .apx-call-desktop { display: inline-block; }
+    }
+    .page-hero {
       padding: 32px 20px 48px;
       text-align: center;
       color: #fff;
     }
-    header h1 {
+    .page-hero h1 {
       margin: 0 0 10px;
       font-size: clamp(1.8rem, 3vw, 2.7rem);
       letter-spacing: 0.02em;
     }
-    header p {
+    .page-hero p {
       margin: 0;
       opacity: 0.85;
     }
@@ -35,13 +65,19 @@
       margin: -40px auto 0;
       box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
     }
-    .back-link {
+    .home-button {
       display: inline-block;
       margin-bottom: 24px;
       font-weight: 600;
       text-decoration: none;
-      color: #ff6b35;
+      color: #fff;
+      background: var(--apx-orange);
+      padding: 10px 18px;
+      border-radius: 999px;
+      transition: background 0.2s ease;
     }
+    .home-button:focus,
+    .home-button:hover { background: #e95d29; }
     h2 {
       font-size: 1.7rem;
       margin-top: 0;
@@ -68,12 +104,23 @@
   </style>
 </head>
 <body>
-  <header>
+  <header class="apx-header">
+    <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+    <nav class="apx-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="about.html" aria-current="page">About</a>
+      <a href="services.html">Services</a>
+      <a href="rebates.html">Rebates</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <a class="apx-call-desktop" href="tel:6044426711">Call: 604-442-6711</a>
+  </header>
+  <section class="page-hero">
     <h1>APEX Heat Pumps</h1>
     <p>CleanBC registered, HPCN certified, and trusted by homeowners across Metro Vancouver.</p>
-  </header>
+  </section>
   <main>
-    <a class="back-link" href="/">← Back to Home</a>
+    <a class="home-button" href="index.html">← Back to Home</a>
     <h2>About Our Team</h2>
     <p>APEX Heating & Cooling Ltd. is a locally owned HVAC contractor specializing in high-efficiency heat pump installations, gas furnace retrofits, and year-round maintenance. Our mission is to deliver reliable comfort, lower utility costs, and quieter homes for families throughout Metro Vancouver.</p>
     <p>From the first site visit to post-installation support, you work directly with technicians who are licensed, insured, and CleanBC Home Performance Contractor Network (HPCN) certified. We design custom solutions for condos, townhomes, and single-family homes, ensuring your system qualifies for the maximum rebates available.</p>

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,8 @@
   <title>Contact APEX Heat Pumps</title>
   <meta name="description" content="Get in touch with APEX Heating & Cooling Ltd. for heat pump installations, service, and 24/7 support in Metro Vancouver.">
   <style>
+    :root { --apx-orange: #ff6b35; --apx-dark: #0e0f11; }
+    * { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: system-ui, -apple-system, Segoe UI, sans-serif;
@@ -13,17 +15,45 @@
       background: #f1f5f9;
       line-height: 1.6;
     }
-    header {
+    a { color: inherit; text-decoration: none; }
+    .apx-header {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      justify-content: space-between;
+      padding: 12px 16px;
+      border-bottom: 1px solid #e2e8f0;
+      position: sticky;
+      top: 0;
+      background: #fff;
+      z-index: 100;
+    }
+    .apx-header .logo { font-weight: 800; color: var(--apx-dark); }
+    .apx-nav a { margin: 0 8px; color: var(--apx-dark); }
+    .apx-nav a[aria-current="page"] { font-weight: 700; text-decoration: underline; }
+    .apx-call-desktop {
+      background: var(--apx-orange);
+      color: #fff;
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-weight: 600;
+      display: none;
+      white-space: nowrap;
+    }
+    @media (min-width: 900px) {
+      .apx-call-desktop { display: inline-block; }
+    }
+    .page-hero {
       background: radial-gradient(circle at top right, #ff6b35, #0e0f11);
       color: #fff;
       padding: 36px 20px 48px;
       text-align: center;
     }
-    header h1 {
+    .page-hero h1 {
       margin: 0 0 10px;
       font-size: clamp(1.9rem, 3vw, 2.8rem);
     }
-    header p {
+    .page-hero p {
       margin: 0;
       opacity: 0.85;
     }
@@ -35,13 +65,19 @@
       border-radius: 32px 32px 0 0;
       box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
     }
-    .back-link {
+    .home-button {
       display: inline-block;
       margin-bottom: 24px;
       text-decoration: none;
       font-weight: 600;
-      color: #ff6b35;
+      color: #fff;
+      background: var(--apx-orange);
+      padding: 10px 18px;
+      border-radius: 999px;
+      transition: background 0.2s ease;
     }
+    .home-button:focus,
+    .home-button:hover { background: #e95d29; }
     .contact-info {
       display: grid;
       gap: 16px;
@@ -58,12 +94,23 @@
   </style>
 </head>
 <body>
-  <header>
+  <header class="apx-header">
+    <a href="index.html" class="logo" aria-label="APEX Heat Pumps home">APEX Heat Pumps</a>
+    <nav class="apx-nav" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="rebates.html">Rebates</a>
+      <a href="contact.html" aria-current="page">Contact</a>
+    </nav>
+    <a class="apx-call-desktop" href="tel:6044426711">Call: 604-442-6711</a>
+  </header>
+  <section class="page-hero">
     <h1>APEX Heat Pumps</h1>
     <p>Licensed HVAC technicians on call for Metro Vancouver homes and businesses.</p>
-  </header>
+  </section>
   <main>
-    <a class="back-link" href="/">← Back to Home</a>
+    <a class="home-button" href="index.html">← Back to Home</a>
     <h2>Contact Our Team</h2>
     <p>We're ready to help with new installations, system upgrades, and emergency repairs. Reach us anytime and we'll respond within one business day.</p>
     <div class="contact-info">


### PR DESCRIPTION
## Summary
- add the shared sticky header navigation to the About and Contact pages with relative links
- highlight the current page using aria-current on each navigation link
- replace the generic back link with a styled Home button tied to index.html

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e274a65184832d85066abda10605bc