### PR TITLE
Replace portfolio images with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,45 +100,31 @@ figcaption{font-size:.9rem;color:#555;margin-top:6px}
   <h2>Heat Pump Installations Across Metro Vancouver</h2>
   <div class="grid">
     <figure>
-      <img loading="lazy" width="800" height="1067"
-           src="/images/heat-pump-line-set-cover-vancouver-balcony-install.jpg"
-           alt="Heat pump line set cover and vent installation on high-rise condo balcony in Vancouver, BC">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>High-rise condo line set sealing • Vancouver, BC</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="1024" height="683"
-           src="/images/ductless-heat-pump-installation-downtown-vancouver-condo.jpg"
-           alt="New ductless mini-split heat pump installed in a downtown Vancouver condo overlooking BC Place">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>Ductless install • Downtown Vancouver</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="768" height="1024"
-           src="/images/airlux-mini-split-heat-pump-installation-surrey-living-room.jpg"
-           alt="Airlux ductless mini-split installed in Surrey living room with line set cover for clean finish">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>Airlux mini-split • Surrey living room</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="1024" height="683"
-           src="/images/airlux-ductless-heat-pump-installation-burnaby-condo.jpg"
-           alt="Ductless Airlux heat pump installation in Burnaby condo with protective plastic during setup">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>Condo retrofit • Burnaby</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="1024" height="768"
-           src="/images/heat-pump-bedroom-installation-vancouver-bc-place-view.jpg"
-           alt="Ductless heat pump indoor unit installed in bedroom with city view of BC Place Stadium in Vancouver">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>Bedroom unit • Vancouver</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="768" height="1024"
-           src="/images/airlux-heat-pump-outdoor-unit-installation-surrey-home.jpg"
-           alt="Airlux outdoor heat pump condenser unit installed outside Surrey home">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>Outdoor condenser • Surrey</figcaption>
     </figure>
     <figure>
-      <img loading="lazy" width="1024" height="683"
-           src="/images/ductless-heat-pump-bedroom-installation-vancouver-highrise.jpg"
-           alt="Ductless heat pump installed in Vancouver high-rise bedroom with teal accent wall">
+      <img src="https://placehold.co/600x400/667eea/white?text=Heat+Pump" alt="Heat Pump">
       <figcaption>High-rise bedroom • Vancouver</figcaption>
     </figure>
   </div>


### PR DESCRIPTION
## Summary
- swap the portfolio gallery assets with consistent placeholder images to avoid broken links
- remove hard-coded dimensions tied to the missing images so the layout relies on intrinsic sizing

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e274a9a2a4832d8b1a25750253b002